### PR TITLE
Mejoras en ext9002: Test librería mejorado y ahora no es necesario que e...

### DIFF
--- a/ext9002-jasper_plugin/patches/jasper_plugin/factinfo_general.qs
+++ b/ext9002-jasper_plugin/patches/jasper_plugin/factinfo_general.qs
@@ -58,7 +58,9 @@ function jasperPlugin_init()
     connect(this.child("cBCodificacion"), "activated(int)", this, "iface.guardaCodificacion");
     connect(this.child("leMaxJVM"), "textChanged(QString)", this, "iface.guardaMaxJVM");;
     this.child("lnJPlugin").text = util.readSettingEntry("jasperplugin/pluginpath");
+    this.child("lnJPlugin").setEnabled(false);
     this.child("lnPath").text = util.readSettingEntry("jasperplugin/reportspath");
+    this.child("lnPath").setEnabled(false);
     this.child("leMaxJVM").text = util.readSettingEntry("jasperplugin/MaxJVM");
     this.child("chbRT").checked = util.readSettingEntry("jasperplugin/detecRT");
     this.child("chbGuardaTemporal").checked = util.readSettingEntry("jasperplugin/guardatemporal");
@@ -97,7 +99,14 @@ function jasperPlugin_testPlugin()
     var util:FLUtil = new FLUtil;
     var ruta:String = this.child("lnJPlugin").text + "enebooreports.jar";
     if (File.exists(ruta))
-    flfactinfo.iface.pub_lanzarInforme(this.cursor(), "version","", "", false, false,"","","","",false);
+    	{
+    	if (flfactinfo.iface.procesoInicializado)
+    		{
+    		flfactinfo.iface.procesoJP.kill();
+    		flfactinfo.iface.procesoInicializado = false;
+    		}
+    	flfactinfo.iface.pub_lanzarInforme(this.cursor(), "version","", "", false, false,"","","","",false);
+        }
      else MessageBox.information(util.translate("scripts", "¡¡ Ruta incorrecta !! \n " + ruta), MessageBox.Ok);
 }
 function jasperPlugin_checkRT()

--- a/ext9002-jasper_plugin/patches/jasper_plugin/flfactinfo.qs
+++ b/ext9002-jasper_plugin/patches/jasper_plugin/flfactinfo.qs
@@ -110,15 +110,18 @@ function jasperPlugin_lanzarInforme(cursor:FLSqlCursor, nombreInforme:String, or
 
             q = this.iface.establecerConsulta(cursor, nombreInforme, orderBy, groupBy, whereFijo);
     //debug("------ CONSULTA -------" + q.sql());
-            if (q.exec() == false) {
+    	  if (util.sqlSelect("flfiles", "nombre", "nombre = '" + nombreInforme + ".qry'"))
+    	  	{
+                 if (q.exec() == false) {
                     MessageBox.critical(util.translate("scripts", "Falló la consulta"), MessageBox.Ok, MessageBox.NoButton);
                     return;
-            } else {
-                    if (q.first() == false) {
-                            MessageBox.warning(util.translate("scripts", "No hay registros que cumplan los criterios de búsqueda establecidos"), MessageBox.Ok, MessageBox.NoButton);
-                            return;
-                    }
-            }
+                 } else {
+                         if (q.first() == false) {
+                         MessageBox.warning(util.translate("scripts", "No hay registros que cumplan los criterios de búsqueda establecidos"), MessageBox.Ok, MessageBox.NoButton);
+                         return;
+                    				}
+            		}
+               }
                  }
             var tipoReport:String = "";
             if (!nombreReport || nombreReport == "") {
@@ -377,6 +380,7 @@ function jasperPlugin_comprobarJasperFisico(reportName:String):Boolean
     if (File.exists(reportName)) return true;
      else
      return false;
+
    }
 
 
@@ -554,6 +558,9 @@ function jasperPlugin_establecerConsulta(cursor:FLSqlCursor, nombreConsulta:Stri
                         where = "1 = 1";
                 where += " GROUP BY " + groupBy;
         }
+        //Si no existe el .qry no continua procesandose la consulta
+	if (!util.sqlSelect("flfiles", "nombre", "nombre = '" + nombreConsulta + ".qry'"))
+		return q;
 
         q.setWhere(where);
 


### PR DESCRIPTION
Se mejora considerablemente la extensión:
Por un lado el control de la librería se mejora a la hora de hacer los test.
Por otro , ya no es necesario que exista un .kut o un .qry para ese tipo de informe, es decir se pueden crear reports jasper totalmente nuevos sin crear un .qry base
